### PR TITLE
UI Rejig

### DIFF
--- a/modules.R
+++ b/modules.R
@@ -15,6 +15,39 @@ contolPanelModal <- function(values){
     numericInput("clipDist", "Clip Dist", value = values$clipDist, min = 0, max = 100, width='100px'),
     sliderInput("fogging", "Fogging:",min = 0, max = 100, value = values$fogging),
     sliderInput("clipping", "Clipping:", min = 0, max = 100, value = values$clipping),
+    selectInput('backgroundColor', 'Background Colour', selected=values$backgroundColor, choices=c('black', 'white')),
+    selectInput('cameraType', 'Camera Type', selected = values$cameraType, choices=c('orthographic', 'perspective')),
+    selectInput('mousePreset', 'Mouse Preset', selected = values$mousePreset, choices=c('default', 'pymol', 'coot')),
     easyClose=FALSE, footer = tagList(actionButton("updateParams", "Update Controls"))
   )
 }
+
+slackPanel <- function(input){
+  modalDialog(title='SlackSlackSlack',
+            fluidPage(
+                tags$head(
+                    tags$style("#chatpanel {overflow: auto;}")
+                ),
+                sidebarLayout(
+                    sidebarPanel(
+                        actionButton('updateSlackChannels', label = 'Update All Slack Channels'),
+                        selectizeInput("channelSelect", "", select='', choices = names(channelSelect), multiple=FALSE, width=-100),
+                        textAreaInput('TextInput', 'Message Body', value = "", width = NULL, height = NULL,
+                        cols = NULL, rows = NULL, placeholder = NULL, resize = 'both'),
+                        textInput('slackUser', label = 'Name', value =''),
+                        actionButton('slackSubmit', label = 'Submit')
+                    ), # sidebarpanel
+                    mainPanel(
+                        absolutePanel(id = 'chatpanel', fixed=T,
+                            #tableOutput('chatTable')]
+                            textOutput('chatURL'),
+                            textOutput('scrollDialog'),
+                            textOutput('chat'),
+                            tags$style(type="text/css", "#chat {white-space: pre-wrap; max-height: 500px}")
+                        )
+                    )
+                )
+            ),
+  easyClose=TRUE, size='l')
+}
+

--- a/server.R
+++ b/server.R
@@ -336,15 +336,25 @@ If you believe you have been sent this message in error, please email tyler.gorr
         list(fogging=c(45,58),
             clipping=c(47,100),
             boxsize=10,
-            clipDist=5)
+            clipDist=5,
+            backgroundColor='black',
+            cameraType='orthographic',
+            mousePreset='default'
+        )
     }
 
     getCurrentParams <- function(input){
         list(fogging=input$fogging,
             clipping=input$clipping,
             boxsize=input$boxsize,
-            clipDist=input$clipDist)
+            clipDist=input$clipDist,
+            backgroundColor=input$backgroundColor,
+            cameraType=input$cameraType,
+            mousePreset=input$mousePreset
+        )
     }
+
+
 
     values <- reactiveValues()
     values$defaults <- loadDefaultParams()
@@ -356,15 +366,33 @@ If you believe you have been sent this message in error, please email tyler.gorr
         showModal(contolPanelModal(values=isolate(values$defaults)))
     })
 
+    observeEvent(input$slackButton, ignoreNULL=TRUE,{
+        updateSelectizeInput(session, 'channelSelect', select=tolower(gsub('[^[:alnum:]]', '', input$Xtal)))
+        showModal(slackPanel(input=NULL))
+    })
+
     observeEvent(input$updateParams, {
         removeModal()
         values$defaults$fogging <- input$fogging
         values$defaults$clipping <- input$clipping
         values$defaults$boxsize <- input$boxsize
         values$defaults$clipDist <- input$clipDist
-        print(values)
+        values$defaults$backgroundColor <- input$backgroundColor
+        values$defaults$cameraType <- input$cameraType
+        values$defaults$mousePreset <- input$mousePreset
     })
 
+    observeEvent(input$backgroundColor,{
+        session$sendCustomMessage('updateaparam', list('backgroundColor', input$backgroundColor))
+    })
+
+    observeEvent(input$cameraType,{
+        session$sendCustomMessage('updateaparam', list('cameraType', input$cameraType))
+    })
+
+    observeEvent(input$mousePreset,{
+        session$sendCustomMessage('updateaparam', list('mousePreset', input$mousePreset))
+    })
 
     # Update behaviour for these...
     observeEvent(input$clickedAtoms, {
@@ -422,6 +450,8 @@ If you believe you have been sent this message in error, please email tyler.gorr
     output$progtext <- renderText({''}) # User Feedback...
     # Observers, behaviour will be described as best as possible
 
+
+    output$ntoreview <- renderText({sprintf('To Review: %s', sum(r1()$Decision==''))})
 
     # Upon Row Click
     observeEvent(input$table_rows_selected, {
@@ -852,9 +882,9 @@ If you believe you have been sent this message in error, please email tyler.gorr
     output$proteinselect <- renderUI({
         query <- parseQueryString(session$clientData$url_search)
         if (!is.null(query[['protein']])) {
-            selectInput('protein', 'Select Specific Protein', choices = proteinList, selected=query[['protein']], multiple=TRUE) 
+            selectInput('protein', 'Select Protein', choices = proteinList, selected=query[['protein']], multiple=TRUE) 
         } else {
-            selectInput('protein', 'Select Specific Protein', choices = proteinList, selected=list(), multiple=TRUE)                  
+            selectInput('protein', 'Select Protein', choices = proteinList, selected=list(), multiple=TRUE)                  
         }
     })
 

--- a/server.R
+++ b/server.R
@@ -153,8 +153,8 @@ With these additional comments:
         protein <- gsub('-x[0-9]+', '', structure)
         sendmailR::sendmail(
             from = '<XChemStructureReview@diamond.ac.uk>',
-            #to = sort(unique(emailListperStructure[[protein]])),#'<tyler.gorrie-stone@diamond.ac.uk>', #emailListperStructure[[structure]],
-            to = '<tyler.gorrie-stone@diamond.ac.uk>',
+            to = sort(unique(emailListperStructure[[protein]])),#'<tyler.gorrie-stone@diamond.ac.uk>', #emailListperStructure[[structure]],
+            #to = '<tyler.gorrie-stone@diamond.ac.uk>',
             subject = sprintf('%s has been labelled as %s', structure, decision),
             msg = sprintf(
 '%s has been labelled as %s by %s for the following reason(s): %s.

--- a/server.R
+++ b/server.R
@@ -335,7 +335,7 @@ If you believe you have been sent this message in error, please email tyler.gorr
     loadDefaultParams <- function(){
         list(fogging=c(45,58),
             clipping=c(47,100),
-            boxsize=10,
+            boxsize=8,
             clipDist=5,
             backgroundColor='black',
             cameraType='orthographic',

--- a/server.R
+++ b/server.R
@@ -335,7 +335,7 @@ If you believe you have been sent this message in error, please email tyler.gorr
     loadDefaultParams <- function(){
         list(fogging=c(45,58),
             clipping=c(47,100),
-            boxsize=8,
+            boxsize=5,
             clipDist=5,
             backgroundColor='black',
             cameraType='orthographic',

--- a/ui.R
+++ b/ui.R
@@ -9,6 +9,7 @@ ui <- navbarPage("XChem Review", id='beep',
             ),
             sidebarLayout(
                 sidebarPanel(width=2,
+                    textOutput('ntoreview'),
                     uiOutput('proteinselect'),
                     div(
                         id = "form",
@@ -27,7 +28,8 @@ ui <- navbarPage("XChem Review", id='beep',
                         column(4, checkboxInput('out5', 'Deposition Ready', value = FALSE)),
                         column(4, checkboxInput('out6', 'Deposited', value = FALSE))
                     ),
-                    actionButton('pictureModal', 'Show Images')
+                    actionButton('pictureModal', 'Show Images'),
+                    actionButton('slackButton', 'Show Slack/History')
                     #imageOutput('ligimage'),
                     #imageOutput('spiderPlot')
                     
@@ -120,32 +122,32 @@ ui <- navbarPage("XChem Review", id='beep',
             ) # Fluid Page
         ) # mainPanel
     ), # tabPanel
-    tabPanel('FragChat',
-        fluidPage(
-                tags$head(
-                    tags$style("#chatpanel {overflow: auto;}")
-                ),
-                sidebarLayout(
-                    sidebarPanel(
-                        actionButton('updateSlackChannels', label = 'Update All Slack Channels'),
-                        selectizeInput("channelSelect", "Channel/Crystal", select='', choices = names(channelSelect), multiple=FALSE),
-                        textAreaInput('TextInput', 'Message Body', value = "", width = NULL, height = NULL,
-                        cols = NULL, rows = NULL, placeholder = NULL, resize = 'both'),
-                        textInput('slackUser', label = 'Name', value =''),
-                        actionButton('slackSubmit', label = 'Submit')
-                    ), # sidebarpanel
-                    mainPanel(
-                        absolutePanel(id = 'chatpanel', fixed=T,
-                            #tableOutput('chatTable')]
-                            textOutput('chatURL'),
-                            textOutput('scrollDialog'),
-                            textOutput('chat'),
-                            tags$style(type="text/css", "#chat {white-space: pre-wrap; max-height: 500px}")
-                        )
-                    ) # Main Panel
-                ) # sidebar layout
-            ) # Fluid Page
-    ), # tabPanel
+    #tabPanel('FragChat',
+    #    fluidPage(
+    #            tags$head(
+    #                tags$style("#chatpanel {overflow: auto;}")
+    #            ),
+    #            sidebarLayout(
+    #                sidebarPanel(
+    #                    actionButton('updateSlackChannels', label = 'Update All Slack Channels'),
+    #                    selectizeInput("channelSelect", "Channel/Crystal", select='', choices = names(channelSelect), multiple=FALSE),
+     #                   textAreaInput('TextInput', 'Message Body', value = "", width = NULL, height = NULL,
+     #                   cols = NULL, rows = NULL, placeholder = NULL, resize = 'both'),
+     #                   textInput('slackUser', label = 'Name', value =''),
+    #                    actionButton('slackSubmit', label = 'Submit')
+    #                ), # sidebarpanel
+    #                mainPanel(
+    #                    absolutePanel(id = 'chatpanel', fixed=T,
+    #                        #tableOutput('chatTable')]
+    #                        textOutput('chatURL'),
+     #                       textOutput('scrollDialog'),
+     #                       textOutput('chat'),
+    #                        tags$style(type="text/css", "#chat {white-space: pre-wrap; max-height: 500px}")
+    #                    )
+    #                ) # Main Panel
+    #            ) # sidebar layout
+    #        ) # Fluid Page
+    #), # tabPanel
 	tabPanel('Help',
 		includeMarkdown(sprintf('%s/%s', gpath, "Pages/include.md"))
 	) # Tab Panel


### PR DESCRIPTION
This PR relates to various UI reorganisation to clean-up the XCR app. 

Notably this puts majority of the NGL controls into a modal pop-up that opens immediately, but also has extra modal dialogs for the Fragment and Slack/History of a given molecule (nice!).

Closes #79 
Closes #77 
Closes #78 
Closes #71 
Closes #62 
Closes #70 
Closes #64 

Additionally, submitting a response now updates the table (and does not reset peoples sessions!

Closes #56 
